### PR TITLE
bringing over r-version integration

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -18,19 +18,19 @@ usage () {
   echo "-m      setup for mac build"
   echo "-w      setup for windows build"
   echo "-l      shiny app requires latex for rendering markdown reports"
-  echo "-d      setup in dev mode, indended for debugging/testing only"
+  echo "-r      specify R version, optional and if not specified pulls latest"
   echo " "
   echo "example:"
   echo ""
   echo "setup -mw"
 }
-while getopts "mwldh" opt;
+while getopts "mwlr:h" opt;
 do
   case ${opt} in
     m) build_mac=1;;
     w) build_win=1;;
     l) add_latex=1;;
-    d) build_for_dev=1;;
+    r) r_version=${OPTARG};;
     h) usage; exit;;
     *) usage; exit;;
   esac
@@ -49,6 +49,12 @@ fi
 if [ -z $add_latex ]
 then
   add_latex=0
+fi
+
+if [ -z $r_version ]
+then
+  echo "Must provide R version, e.g., '4.0.2'"
+  exit 1
 fi
 
 if [[ $build_mac == 0 && $build_win == 0 ]]
@@ -74,7 +80,7 @@ then
   # get R binary for mac if not already pulled
   if [[ ! -f ./r-mac/bin/R ]]
   then
-    ./setup_scripts/get-r-mac.sh
+    ./setup_scripts/get-r-mac.sh $r_version
   else
     echo "R binary already exists for mac or not needed, skipping."
   fi
@@ -97,7 +103,7 @@ then
   # get R binary for mac if not already pulled
   if [[ ! -f ./r-win/bin/x64/R.exe ]]
   then
-    ./setup_scripts/get-r-win.sh
+    ./setup_scripts/get-r-win.sh $r_version
   else
     echo "R binary already exists for win or not needed, skipping."
   fi

--- a/setup_scripts/get-r-mac.sh
+++ b/setup_scripts/get-r-mac.sh
@@ -1,18 +1,30 @@
 #!/usr/bin/env bash
 set -e
 
+r_version=$1
+
 # Download and extract the main Mac Resources directory
 # Requires xar and cpio, both installed in the Dockerfile
 mkdir -p ./r-mac
 curl -o ./r-mac/latest_r.pkg \
-     https://cloud.r-project.org/bin/macosx/R-4.0.2.pkg
+     https://cloud.r-project.org/bin/macosx/R-$r_version.pkg
 
 cd ./r-mac
 xar -xf latest_r.pkg
-rm -r r-1.pkg Resources tcltk8.pkg texinfo5.pkg Distribution latest_r.pkg
-cat r.pkg/Payload | gunzip -dc | cpio -i
-mv R.framework/Versions/Current/Resources/* .
-rm -r r.pkg R.framework
+
+# R version 4.0.0+ has different .pkg contents
+if [[ ! -f r.pkg ]]
+then
+  rm -r R-app.pkg Resources tcltk.pkg texinfo.pkg Distribution latest_r.pkg
+  cat R-fw.pkg/Payload | gunzip -dc | cpio -i
+  mv R.framework/Versions/Current/Resources/* .
+  rm -r R-fw.pkg R.framework
+else
+  rm -r r-1.pkg Resources tcltk8.pkg texinfo5.pkg Distribution latest_r.pkg
+  cat r.pkg/Payload | gunzip -dc | cpio -i
+  mv R.framework/Versions/Current/Resources/* .
+  rm -r r.pkg R.framework
+fi
 
 # need to make sure R is looking in the right place - packaged electron - for
 # paths, otherwise the app will break unless user installs R on machine; this

--- a/setup_scripts/get-r-win.sh
+++ b/setup_scripts/get-r-win.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
+r_version=$1
+
 # Download and extract the Windows binary install
 # Requires innoextract
 mkdir -p ./r-win
 curl -o ./r-win/latest_r.exe \
-  https://cloud.r-project.org/bin/windows/base/old/4.0.2/R-4.0.2-win.exe
+  https://cloud.r-project.org/bin/windows/base/old/$r_version/R-$r_version-win.exe
 
 cd ./r-win
 innoextract -e latest_r.exe


### PR DESCRIPTION
user must now specify r version, compatible with old 3.X as well as new 4.X versions for mac and windows.